### PR TITLE
Add %AIG_TOOL layer for configurable ABC optimization between synthes…

### DIFF
--- a/.github/actions/run-benchmark/action.yml
+++ b/.github/actions/run-benchmark/action.yml
@@ -1,0 +1,61 @@
+name: Run Benchmark
+description: Run lit benchmarks for one configuration and aggregate results
+
+inputs:
+  synth_tool:
+    description: 'Synthesis tool to use (circt or yosys)'
+    required: true
+  bitwidths:
+    description: 'Comma-separated list of bitwidths'
+    required: false
+    default: '16,48'
+  abc_commands:
+    description: 'ABC commands to pass as ABC_COMMANDS lit param'
+    required: false
+    default: ''
+  circt_synth_extra_args:
+    description: 'Extra circt-synth args to pass as CIRCT_SYNTH_EXTRA_ARGS lit param'
+    required: false
+    default: ''
+  output_dir:
+    description: 'Lit TEST_OUTPUT_DIR'
+    required: true
+  tool_label:
+    description: 'Label passed to aggregate-results --tool'
+    required: true
+  tool_version:
+    description: 'Version string passed to aggregate-results --version'
+    required: true
+  summary_file:
+    description: 'Output JSON summary file path'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Run lit benchmarks
+      shell: bash
+      run: |
+        source .venv/bin/activate
+        ABC_PARAM=""
+        [ -n "${{ inputs.abc_commands }}" ] && ABC_PARAM="-DABC_COMMANDS=\"${{ inputs.abc_commands }}\""
+        EXTRA_PARAM=""
+        [ -n "${{ inputs.circt_synth_extra_args }}" ] && EXTRA_PARAM="-DCIRCT_SYNTH_EXTRA_ARGS=\"${{ inputs.circt_synth_extra_args }}\""
+        IFS=',' read -ra BWS <<< "${{ inputs.bitwidths }}"
+        for BW in "${BWS[@]}"; do
+          eval lit -v benchmarks/ \
+            -DSYNTH_TOOL=${{ inputs.synth_tool }} \
+            -DTEST_OUTPUT_DIR=${{ inputs.output_dir }} \
+            -DBW=$BW \
+            $ABC_PARAM $EXTRA_PARAM || true
+        done
+
+    - name: Aggregate results
+      shell: bash
+      run: |
+        source .venv/bin/activate
+        aggregate-results \
+          --tool "${{ inputs.tool_label }}" \
+          --version "${{ inputs.tool_version }}" \
+          --results-dir ${{ inputs.output_dir }} \
+          -o ${{ inputs.summary_file }}

--- a/.github/actions/setup-tracker/action.yml
+++ b/.github/actions/setup-tracker/action.yml
@@ -1,0 +1,20 @@
+name: Setup Tracker
+description: Install uv, Python dependencies, and build aig-judge
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      shell: bash
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+    - name: Install Python dependencies
+      shell: bash
+      run: uv sync
+
+    - name: Build aig-judge
+      shell: bash
+      run: uv run build-judge

--- a/.github/workflows/ci-experiment.yml
+++ b/.github/workflows/ci-experiment.yml
@@ -1,0 +1,156 @@
+name: Experiment
+
+on:
+  workflow_dispatch:
+    inputs:
+      # Configuration A
+      synth_tool_a:
+        description: 'Synth tool for config A'
+        required: false
+        default: 'circt'
+        type: choice
+        options: [circt, yosys]
+      abc_commands_a:
+        description: 'ABC commands for config A via %AIG_TOOL (e.g. "dc2; dc2;")'
+        required: false
+        default: ''
+      circt_synth_extra_args_a:
+        description: 'Extra circt-synth args for config A (e.g. "--pass-pipeline=...")'
+        required: false
+        default: ''
+
+      # Configuration B
+      synth_tool_b:
+        description: 'Synth tool for config B'
+        required: false
+        default: 'circt'
+        type: choice
+        options: [circt, yosys]
+      abc_commands_b:
+        description: 'ABC commands for config B via %AIG_TOOL (e.g. "dc2; dc2; dc2;")'
+        required: false
+        default: ''
+      circt_synth_extra_args_b:
+        description: 'Extra circt-synth args for config B'
+        required: false
+        default: ''
+
+      # Shared settings
+      bitwidths:
+        description: 'Comma-separated list of bitwidths to test'
+        required: false
+        default: '16,48'
+
+permissions:
+  contents: read
+
+jobs:
+  experiment:
+    name: "A=${{ inputs.synth_tool_a }} vs B=${{ inputs.synth_tool_b }}"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/circt/images/circt-integration-test:v20
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install jq
+        run: apt-get update && apt-get install -y jq
+
+      - name: Install CIRCT nightly
+        uses: circt/install-circt@3f8dda6e1c1965537b5801a43c81c287bac4eae4 # v1.1.1
+        with:
+          version: 'nightly'
+          github-token: ${{ github.token }}
+
+      - name: Add CIRCT to PATH
+        run: echo "$GITHUB_WORKSPACE/circt/bin" >> $GITHUB_PATH
+
+      - name: Get tool versions
+        run: |
+          CIRCT_VERSION=$(circt-synth --version | tail -1 | xargs)
+          YOSYS_VERSION=$(yosys --version | head -1 | xargs)
+          echo "CIRCT_VERSION=$CIRCT_VERSION" >> $GITHUB_ENV
+          echo "YOSYS_VERSION=$YOSYS_VERSION" >> $GITHUB_ENV
+          echo "CIRCT: $CIRCT_VERSION"
+          echo "Yosys: $YOSYS_VERSION"
+
+      - name: Setup tracker
+        uses: ./.github/actions/setup-tracker
+
+      - name: Run config A
+        uses: ./.github/actions/run-benchmark
+        with:
+          synth_tool: ${{ inputs.synth_tool_a }}
+          bitwidths: ${{ inputs.bitwidths }}
+          abc_commands: ${{ inputs.abc_commands_a }}
+          circt_synth_extra_args: ${{ inputs.circt_synth_extra_args_a }}
+          output_dir: build_a
+          tool_label: a
+          tool_version: ${{ env.CIRCT_VERSION }}
+          summary_file: summary_a.json
+
+      - name: Run config B
+        uses: ./.github/actions/run-benchmark
+        with:
+          synth_tool: ${{ inputs.synth_tool_b }}
+          bitwidths: ${{ inputs.bitwidths }}
+          abc_commands: ${{ inputs.abc_commands_b }}
+          circt_synth_extra_args: ${{ inputs.circt_synth_extra_args_b }}
+          output_dir: build_b
+          tool_label: b
+          tool_version: ${{ env.CIRCT_VERSION }}
+          summary_file: summary_b.json
+
+      - name: Compare A vs B
+        run: |
+          source .venv/bin/activate
+          compare-results summary_a.json summary_b.json -o report.html
+          compare-results summary_a.json summary_b.json -o report.md
+          compare-results summary_a.json summary_b.json -o report.json --format json
+
+      - name: Post summary
+        if: always()
+        run: |
+          {
+            echo "## Experiment Results"
+            echo ""
+            echo "| | Config A | Config B |"
+            echo "|---|---|---|"
+            echo "| Synth tool | \`${{ inputs.synth_tool_a }}\` | \`${{ inputs.synth_tool_b }}\` |"
+            echo "| ABC commands | \`${{ inputs.abc_commands_a || '(none)' }}\` | \`${{ inputs.abc_commands_b || '(none)' }}\` |"
+            echo "| Extra args | \`${{ inputs.circt_synth_extra_args_a || '(none)' }}\` | \`${{ inputs.circt_synth_extra_args_b || '(none)' }}\` |"
+            echo "| CIRCT version | \`${CIRCT_VERSION}\` | \`${CIRCT_VERSION}\` |"
+            echo ""
+            if [ -f report.md ]; then
+              cat report.md
+            fi
+          } >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: experiment-results
+          retention-days: 30
+          path: |
+            report.html
+            report.md
+            report.json
+            summary_a.json
+            summary_b.json
+
+      - name: Upload test outputs on failure
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: experiment-test-outputs
+          path: |
+            build_a/
+            build_b/

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -10,6 +10,10 @@ on:
         description: 'Comma-separated list of bitwidths to test (e.g. "16,32")'
         required: false
         default: '16,48'
+      abc_commands:
+        description: 'ABC commands to run on AIG after synthesis via %AIG_TOOL (e.g. "dc2; dc2;")'
+        required: false
+        default: ''
   pull_request:
     branches:
       - main
@@ -61,11 +65,6 @@ jobs:
           echo "CIRCT Version: $CIRCT_VERSION"
           echo "Yosys Version: $YOSYS_VERSION"
 
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
       - name: Verify environment
         run: |
           which yosys
@@ -75,39 +74,30 @@ jobs:
           yosys --version
           circt-synth --version
 
-      - name: Install Python dependencies
-        run: |
-          uv sync
-
-      - name: Build aig-judge
-        run: |
-          uv run build-judge
+      - name: Setup tracker
+        uses: ./.github/actions/setup-tracker
 
       - name: Run CIRCT tests
-        run: |
-          source .venv/bin/activate
-          IFS=',' read -ra BWS <<< "${{ github.event.inputs.bitwidths || '16,48' }}"
-          for BW in "${BWS[@]}"; do
-            lit -v benchmarks/ -DSYNTH_TOOL=circt -DTEST_OUTPUT_DIR=build_circt -DBW=$BW || true
-          done
+        uses: ./.github/actions/run-benchmark
+        with:
+          synth_tool: circt
+          bitwidths: ${{ github.event.inputs.bitwidths || '16,48' }}
+          abc_commands: ${{ github.event.inputs.abc_commands }}
+          output_dir: build_circt
+          tool_label: circt
+          tool_version: ${{ env.CIRCT_VERSION }}
+          summary_file: circt-summary.json
 
       - name: Run Yosys tests
-        run: |
-          source .venv/bin/activate
-          IFS=',' read -ra BWS <<< "${{ github.event.inputs.bitwidths || '16,48' }}"
-          for BW in "${BWS[@]}"; do
-            lit -v benchmarks/ -DSYNTH_TOOL=yosys -DTEST_OUTPUT_DIR=build_yosys -DBW=$BW || true
-          done
-
-      - name: Aggregate CIRCT results
-        run: |
-          source .venv/bin/activate
-          aggregate-results --tool circt --version "$CIRCT_VERSION" --results-dir build_circt -o circt-summary.json
-
-      - name: Aggregate Yosys results
-        run: |
-          source .venv/bin/activate
-          aggregate-results --tool yosys --version "$YOSYS_VERSION" --results-dir build_yosys -o yosys-summary.json
+        uses: ./.github/actions/run-benchmark
+        with:
+          synth_tool: yosys
+          bitwidths: ${{ github.event.inputs.bitwidths || '16,48' }}
+          abc_commands: ${{ github.event.inputs.abc_commands }}
+          output_dir: build_yosys
+          tool_label: yosys
+          tool_version: ${{ env.YOSYS_VERSION }}
+          summary_file: yosys-summary.json
 
       - name: Compare results
         run: |

--- a/.github/workflows/ci-pr-benchmark.yml
+++ b/.github/workflows/ci-pr-benchmark.yml
@@ -11,6 +11,10 @@ on:
         description: 'Comma-separated list of bitwidths to test'
         required: false
         default: '16,48'
+      abc_commands:
+        description: 'ABC commands to run on AIG after synthesis via %AIG_TOOL (e.g. "dc2; dc2;")'
+        required: false
+        default: ''
       issue_number:
         description: 'Tracker issue number to post results to (optional)'
         required: false
@@ -113,8 +117,8 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install Python dependencies and build aig-judge
+        working-directory: tracker
         run: |
-          cd tracker
           uv sync
           uv run build-judge
 
@@ -152,10 +156,12 @@ jobs:
           echo "CIRCT_VERSION_BEFORE=$BEFORE_VERSION" >> $GITHUB_ENV
           cd tracker
           source .venv/bin/activate
+          ABC_COMMANDS="${{ inputs.abc_commands }}"
+          ABC_PARAM="${ABC_COMMANDS:+-DABC_COMMANDS=\"$ABC_COMMANDS\"}"
           IFS=',' read -ra BWS <<< "${{ inputs.bitwidths || '16,48' }}"
           for BW in "${BWS[@]}"; do
             lit -v benchmarks/ -DSYNTH_TOOL=circt \
-              -DTEST_OUTPUT_DIR=build_before -DBW=$BW || true
+              -DTEST_OUTPUT_DIR=build_before -DBW=$BW $ABC_PARAM || true
           done
           aggregate-results --tool "base" --version "$BEFORE_VERSION" \
             --results-dir build_before -o before-summary.json
@@ -194,10 +200,12 @@ jobs:
           echo "CIRCT_VERSION_AFTER=$AFTER_VERSION" >> $GITHUB_ENV
           cd tracker
           source .venv/bin/activate
+          ABC_COMMANDS="${{ inputs.abc_commands }}"
+          ABC_PARAM="${ABC_COMMANDS:+-DABC_COMMANDS=\"$ABC_COMMANDS\"}"
           IFS=',' read -ra BWS <<< "${{ inputs.bitwidths || '16,48' }}"
           for BW in "${BWS[@]}"; do
             lit -v benchmarks/ -DSYNTH_TOOL=circt \
-              -DTEST_OUTPUT_DIR=build_after -DBW=$BW || true
+              -DTEST_OUTPUT_DIR=build_after -DBW=$BW $ABC_PARAM || true
           done
           aggregate-results --tool "pr" --version "$AFTER_VERSION" \
             --results-dir build_after -o after-summary.json

--- a/benchmarks/comb/DatapathBench/tests/AddMop.test
+++ b/benchmarks/comb/DatapathBench/tests/AddMop.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/AddMop/sv/AddMop.sv --bw %BW -top AddMop -o %t.aig
-RUN: %judge %t.aig | %submit %s --name AddMop
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name AddMop

--- a/benchmarks/comb/DatapathBench/tests/AddMulSgn.test
+++ b/benchmarks/comb/DatapathBench/tests/AddMulSgn.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/AddMulSgn/sv/AddMulSgn.sv --bw %BW -top AddMulSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name AddMulSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name AddMulSgn

--- a/benchmarks/comb/DatapathBench/tests/AddMulUns.test
+++ b/benchmarks/comb/DatapathBench/tests/AddMulUns.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/AddMulUns/sv/AddMulUns.sv --bw %BW -top AddMulUns -o %t.aig
-RUN: %judge %t.aig | %submit %s --name AddMulUns
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name AddMulUns

--- a/benchmarks/comb/DatapathBench/tests/AddThree.test
+++ b/benchmarks/comb/DatapathBench/tests/AddThree.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/AddThree/sv/AddThree.sv --bw %BW -top AddThree -o %t.aig
-RUN: %judge %t.aig | %submit %s --name AddThree
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name AddThree

--- a/benchmarks/comb/DatapathBench/tests/AddThreeSgn.test
+++ b/benchmarks/comb/DatapathBench/tests/AddThreeSgn.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/AddThreeSgn/sv/AddThreeSgn.sv --bw %BW -top AddThreeSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name AddThreeSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name AddThreeSgn

--- a/benchmarks/comb/DatapathBench/tests/AlphaBlend.test
+++ b/benchmarks/comb/DatapathBench/tests/AlphaBlend.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/AlphaBlend/sv/AlphaBlend.sv --bw %BW -top AlphaBlend -o %t.aig
-RUN: %judge %t.aig | %submit %s --name AlphaBlend
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name AlphaBlend

--- a/benchmarks/comb/DatapathBench/tests/CarrySaveCompare.test
+++ b/benchmarks/comb/DatapathBench/tests/CarrySaveCompare.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/CarrySaveCompare/sv/CarrySaveCompare.sv --bw %BW -top CarrySaveCompare -o %t.aig
-RUN: %judge %t.aig | %submit %s --name CarrySaveCompare
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name CarrySaveCompare

--- a/benchmarks/comb/DatapathBench/tests/CarrySaveSelect.test
+++ b/benchmarks/comb/DatapathBench/tests/CarrySaveSelect.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/CarrySaveSelect/sv/CarrySaveSelect.sv --bw %BW -top CarrySaveSelect -o %t.aig
-RUN: %judge %t.aig | %submit %s --name CarrySaveSelect
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name CarrySaveSelect

--- a/benchmarks/comb/DatapathBench/tests/DotProduct.test
+++ b/benchmarks/comb/DatapathBench/tests/DotProduct.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/DotProduct/sv/DotProduct.sv --bw %BW -top DotProduct -o %t.aig
-RUN: %judge %t.aig | %submit %s --name DotProduct
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name DotProduct

--- a/benchmarks/comb/DatapathBench/tests/DotProductSgn.test
+++ b/benchmarks/comb/DatapathBench/tests/DotProductSgn.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/DotProductSgn/sv/DotProductSgn.sv --bw %BW -top DotProductSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name DotProductSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name DotProductSgn

--- a/benchmarks/comb/DatapathBench/tests/Fma.test
+++ b/benchmarks/comb/DatapathBench/tests/Fma.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/Fma/sv/Fma.sv --bw %BW -top Fma -o %t.aig
-RUN: %judge %t.aig | %submit %s --name Fma
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name Fma

--- a/benchmarks/comb/DatapathBench/tests/FmaSgn.test
+++ b/benchmarks/comb/DatapathBench/tests/FmaSgn.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/FmaSgn/sv/FmaSgn.sv --bw %BW -top FmaSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name FmaSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name FmaSgn

--- a/benchmarks/comb/DatapathBench/tests/FmaShare.test
+++ b/benchmarks/comb/DatapathBench/tests/FmaShare.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/FmaShare/sv/FmaShare.sv --bw %BW -top FmaShare -o %t.aig
-RUN: %judge %t.aig | %submit %s --name FmaShare
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name FmaShare

--- a/benchmarks/comb/DatapathBench/tests/FmaShareSgn.test
+++ b/benchmarks/comb/DatapathBench/tests/FmaShareSgn.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/FmaShareSgn/sv/FmaShareSgn.sv --bw %BW -top FmaShareSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name FmaShareSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name FmaShareSgn

--- a/benchmarks/comb/DatapathBench/tests/Fmaa.test
+++ b/benchmarks/comb/DatapathBench/tests/Fmaa.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/Fmaa/sv/Fmaa.sv --bw %BW -top Fmaa -o %t.aig
-RUN: %judge %t.aig | %submit %s --name Fmaa
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name Fmaa

--- a/benchmarks/comb/DatapathBench/tests/FmaaSgn.test
+++ b/benchmarks/comb/DatapathBench/tests/FmaaSgn.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/FmaaSgn/sv/FmaaSgn.sv --bw %BW -top FmaaSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name FmaaSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name FmaaSgn

--- a/benchmarks/comb/DatapathBench/tests/MulAddSgn.test
+++ b/benchmarks/comb/DatapathBench/tests/MulAddSgn.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/MulAddSgn/sv/MulAddSgn.sv --bw %BW -top MulAddSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name MulAddSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name MulAddSgn

--- a/benchmarks/comb/DatapathBench/tests/MulAddUns.test
+++ b/benchmarks/comb/DatapathBench/tests/MulAddUns.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/MulAddUns/sv/MulAddUns.sv --bw %BW -top MulAddUns -o %t.aig
-RUN: %judge %t.aig | %submit %s --name MulAddUns
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name MulAddUns

--- a/benchmarks/comb/DatapathBench/tests/MulThree.test
+++ b/benchmarks/comb/DatapathBench/tests/MulThree.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/MulThree/sv/MulThree.sv --bw %BW -top MulThree -o %t.aig
-RUN: %judge %t.aig | %submit %s --name MulThree
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name MulThree

--- a/benchmarks/comb/DatapathBench/tests/MulThreeSgn.test
+++ b/benchmarks/comb/DatapathBench/tests/MulThreeSgn.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/MulThreeSgn/sv/MulThreeSgn.sv --bw %BW -top MulThreeSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name MulThreeSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name MulThreeSgn

--- a/benchmarks/comb/DatapathBench/tests/SqrSgn.test
+++ b/benchmarks/comb/DatapathBench/tests/SqrSgn.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/SqrSgn/sv/SqrSgn.sv --bw %BW -top SqrSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name SqrSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name SqrSgn

--- a/benchmarks/comb/DatapathBench/tests/SqrUns.test
+++ b/benchmarks/comb/DatapathBench/tests/SqrUns.test
@@ -1,2 +1,3 @@
 RUN: %SYNTH_TOOL %S/../DatapathBench/benchmarks/SqrUns/sv/SqrUns.sv --bw %BW -top SqrUns -o %t.aig
-RUN: %judge %t.aig | %submit %s --name SqrUns
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name SqrUns

--- a/benchmarks/comb/ELAU/generate_tests.py
+++ b/benchmarks/comb/ELAU/generate_tests.py
@@ -36,7 +36,8 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/{file_name}.sv  --libdir 
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top {top_module} -o %t.aig
-RUN: %judge %t.aig | %submit %s --name {top_module}
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name {top_module}
         """
 
         # Write to tests/{file_name}.test

--- a/benchmarks/comb/ELAU/tests/AbsVal.test
+++ b/benchmarks/comb/ELAU/tests/AbsVal.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AbsVal.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AbsVal -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AbsVal
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AbsVal

--- a/benchmarks/comb/ELAU/tests/Add.test
+++ b/benchmarks/comb/ELAU/tests/Add.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Add.sv  --libdir %ELAU_SR
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Add -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Add
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Add

--- a/benchmarks/comb/ELAU/tests/AddC.test
+++ b/benchmarks/comb/ELAU/tests/AddC.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddC.sv  --libdir %ELAU_S
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddC -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddC
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddC

--- a/benchmarks/comb/ELAU/tests/AddCfast.test
+++ b/benchmarks/comb/ELAU/tests/AddCfast.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddCfast.sv  --libdir %EL
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddCfast -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddCfast
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddCfast

--- a/benchmarks/comb/ELAU/tests/AddCsv.test
+++ b/benchmarks/comb/ELAU/tests/AddCsv.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddCsv.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddCsv -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddCsv
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddCsv

--- a/benchmarks/comb/ELAU/tests/AddMod2Nm1.test
+++ b/benchmarks/comb/ELAU/tests/AddMod2Nm1.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddMod2Nm1.sv  --libdir %
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddMod2Nm1 -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddMod2Nm1
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddMod2Nm1

--- a/benchmarks/comb/ELAU/tests/AddMod2Nm1s0.test
+++ b/benchmarks/comb/ELAU/tests/AddMod2Nm1s0.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddMod2Nm1s0.sv  --libdir
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddMod2Nm1s0 -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddMod2Nm1s0
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddMod2Nm1s0

--- a/benchmarks/comb/ELAU/tests/AddMop.test
+++ b/benchmarks/comb/ELAU/tests/AddMop.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddMop.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddMop -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddMop
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddMop

--- a/benchmarks/comb/ELAU/tests/AddMulUns.test
+++ b/benchmarks/comb/ELAU/tests/AddMulUns.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddMulUns.sv  --libdir %E
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddMulUns -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddMulUns
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddMulUns

--- a/benchmarks/comb/ELAU/tests/AddSub.test
+++ b/benchmarks/comb/ELAU/tests/AddSub.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddSub.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddSub -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddSub
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddSub

--- a/benchmarks/comb/ELAU/tests/AddSubC.test
+++ b/benchmarks/comb/ELAU/tests/AddSubC.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddSubC.sv  --libdir %ELA
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddSubC -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddSubC
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddSubC

--- a/benchmarks/comb/ELAU/tests/AddSubV.test
+++ b/benchmarks/comb/ELAU/tests/AddSubV.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddSubV.sv  --libdir %ELA
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddSubV -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddSubV
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddSubV

--- a/benchmarks/comb/ELAU/tests/AddV.test
+++ b/benchmarks/comb/ELAU/tests/AddV.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AddV.sv  --libdir %ELAU_S
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AddV -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AddV
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AddV

--- a/benchmarks/comb/ELAU/tests/AllOneDet.test
+++ b/benchmarks/comb/ELAU/tests/AllOneDet.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AllOneDet.sv  --libdir %E
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AllOneDet -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AllOneDet
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AllOneDet

--- a/benchmarks/comb/ELAU/tests/AllZeroDet.test
+++ b/benchmarks/comb/ELAU/tests/AllZeroDet.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/AllZeroDet.sv  --libdir %
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_AllZeroDet -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_AllZeroDet
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_AllZeroDet

--- a/benchmarks/comb/ELAU/tests/Bin2Gray.test
+++ b/benchmarks/comb/ELAU/tests/Bin2Gray.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Bin2Gray.sv  --libdir %EL
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Bin2Gray -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Bin2Gray
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Bin2Gray

--- a/benchmarks/comb/ELAU/tests/CmpEQ.test
+++ b/benchmarks/comb/ELAU/tests/CmpEQ.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/CmpEQ.sv  --libdir %ELAU_
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_CmpEQ -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_CmpEQ
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_CmpEQ

--- a/benchmarks/comb/ELAU/tests/CmpEQGE.test
+++ b/benchmarks/comb/ELAU/tests/CmpEQGE.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/CmpEQGE.sv  --libdir %ELA
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_CmpEQGE -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_CmpEQGE
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_CmpEQGE

--- a/benchmarks/comb/ELAU/tests/CmpGE.test
+++ b/benchmarks/comb/ELAU/tests/CmpGE.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/CmpGE.sv  --libdir %ELAU_
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_CmpGE -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_CmpGE
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_CmpGE

--- a/benchmarks/comb/ELAU/tests/Cnt.test
+++ b/benchmarks/comb/ELAU/tests/Cnt.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Cnt.sv  --libdir %ELAU_SR
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Cnt -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Cnt
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Cnt

--- a/benchmarks/comb/ELAU/tests/Dec.test
+++ b/benchmarks/comb/ELAU/tests/Dec.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Dec.sv  --libdir %ELAU_SR
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Dec -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Dec
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Dec

--- a/benchmarks/comb/ELAU/tests/DecC.test
+++ b/benchmarks/comb/ELAU/tests/DecC.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/DecC.sv  --libdir %ELAU_S
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_DecC -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_DecC
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_DecC

--- a/benchmarks/comb/ELAU/tests/Decode.test
+++ b/benchmarks/comb/ELAU/tests/Decode.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Decode.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Decode -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Decode
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Decode

--- a/benchmarks/comb/ELAU/tests/FullAdder.test
+++ b/benchmarks/comb/ELAU/tests/FullAdder.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/FullAdder.sv  --libdir %E
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_FullAdder -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_FullAdder
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_FullAdder

--- a/benchmarks/comb/ELAU/tests/Gray2Bin.test
+++ b/benchmarks/comb/ELAU/tests/Gray2Bin.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Gray2Bin.sv  --libdir %EL
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Gray2Bin -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Gray2Bin
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Gray2Bin

--- a/benchmarks/comb/ELAU/tests/Inc.test
+++ b/benchmarks/comb/ELAU/tests/Inc.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Inc.sv  --libdir %ELAU_SR
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Inc -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Inc
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Inc

--- a/benchmarks/comb/ELAU/tests/IncC.test
+++ b/benchmarks/comb/ELAU/tests/IncC.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/IncC.sv  --libdir %ELAU_S
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_IncC -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_IncC
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_IncC

--- a/benchmarks/comb/ELAU/tests/IncDec.test
+++ b/benchmarks/comb/ELAU/tests/IncDec.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/IncDec.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_IncDec -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_IncDec
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_IncDec

--- a/benchmarks/comb/ELAU/tests/IncDecC.test
+++ b/benchmarks/comb/ELAU/tests/IncDecC.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/IncDecC.sv  --libdir %ELA
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_IncDecC -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_IncDecC
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_IncDecC

--- a/benchmarks/comb/ELAU/tests/LeadOneDet.test
+++ b/benchmarks/comb/ELAU/tests/LeadOneDet.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/LeadOneDet.sv  --libdir %
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_LeadOneDet -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_LeadOneDet
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_LeadOneDet

--- a/benchmarks/comb/ELAU/tests/LeadSignDet.test
+++ b/benchmarks/comb/ELAU/tests/LeadSignDet.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/LeadSignDet.sv  --libdir 
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_LeadSignDet -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_LeadSignDet
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_LeadSignDet

--- a/benchmarks/comb/ELAU/tests/LeadZeroDet.test
+++ b/benchmarks/comb/ELAU/tests/LeadZeroDet.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/LeadZeroDet.sv  --libdir 
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_LeadZeroDet -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_LeadZeroDet
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_LeadZeroDet

--- a/benchmarks/comb/ELAU/tests/Log2.test
+++ b/benchmarks/comb/ELAU/tests/Log2.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Log2.sv  --libdir %ELAU_S
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Log2 -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Log2
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Log2

--- a/benchmarks/comb/ELAU/tests/MulAddSgn.test
+++ b/benchmarks/comb/ELAU/tests/MulAddSgn.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/MulAddSgn.sv  --libdir %E
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_MulAddSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_MulAddSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_MulAddSgn

--- a/benchmarks/comb/ELAU/tests/MulAddUns.test
+++ b/benchmarks/comb/ELAU/tests/MulAddUns.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/MulAddUns.sv  --libdir %E
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_MulAddUns -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_MulAddUns
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_MulAddUns

--- a/benchmarks/comb/ELAU/tests/MulSgn.test
+++ b/benchmarks/comb/ELAU/tests/MulSgn.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/MulSgn.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_MulSgn -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_MulSgn
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_MulSgn

--- a/benchmarks/comb/ELAU/tests/MulUns.test
+++ b/benchmarks/comb/ELAU/tests/MulUns.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/MulUns.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_MulUns -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_MulUns
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_MulUns

--- a/benchmarks/comb/ELAU/tests/Neg.test
+++ b/benchmarks/comb/ELAU/tests/Neg.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Neg.sv  --libdir %ELAU_SR
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Neg -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Neg
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Neg

--- a/benchmarks/comb/ELAU/tests/NegC.test
+++ b/benchmarks/comb/ELAU/tests/NegC.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/NegC.sv  --libdir %ELAU_S
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_NegC -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_NegC
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_NegC

--- a/benchmarks/comb/ELAU/tests/RedAnd.test
+++ b/benchmarks/comb/ELAU/tests/RedAnd.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/RedAnd.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_RedAnd -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_RedAnd
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_RedAnd

--- a/benchmarks/comb/ELAU/tests/RedOr.test
+++ b/benchmarks/comb/ELAU/tests/RedOr.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/RedOr.sv  --libdir %ELAU_
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_RedOr -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_RedOr
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_RedOr

--- a/benchmarks/comb/ELAU/tests/RedXor.test
+++ b/benchmarks/comb/ELAU/tests/RedXor.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/RedXor.sv  --libdir %ELAU
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_RedXor -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_RedXor
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_RedXor

--- a/benchmarks/comb/ELAU/tests/Sub.test
+++ b/benchmarks/comb/ELAU/tests/Sub.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/Sub.sv  --libdir %ELAU_SR
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_Sub -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_Sub
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_Sub

--- a/benchmarks/comb/ELAU/tests/SubC.test
+++ b/benchmarks/comb/ELAU/tests/SubC.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/SubC.sv  --libdir %ELAU_S
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_SubC -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_SubC
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_SubC

--- a/benchmarks/comb/ELAU/tests/SubCZ.test
+++ b/benchmarks/comb/ELAU/tests/SubCZ.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/SubCZ.sv  --libdir %ELAU_
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_SubCZ -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_SubCZ
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_SubCZ

--- a/benchmarks/comb/ELAU/tests/SubV.test
+++ b/benchmarks/comb/ELAU/tests/SubV.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/SubV.sv  --libdir %ELAU_S
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_SubV -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_SubV
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_SubV

--- a/benchmarks/comb/ELAU/tests/SubVZ.test
+++ b/benchmarks/comb/ELAU/tests/SubVZ.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/SubVZ.sv  --libdir %ELAU_
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_SubVZ -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_SubVZ
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_SubVZ

--- a/benchmarks/comb/ELAU/tests/SumZeroDet.test
+++ b/benchmarks/comb/ELAU/tests/SumZeroDet.test
@@ -4,4 +4,5 @@ RUN: circt-verilog %ELAU_SRC/arith_utils.sv  %ELAU_SRC/SumZeroDet.sv  --libdir %
 RUN: circt-opt -export-verilog %t.sv.mlir -o /dev/null > %t.sv
 // Note: BW is not passed here since the generated verilog already has the parameter instantiated
 RUN: %SYNTH_TOOL %t.sv -top behavioural_SumZeroDet -o %t.aig
-RUN: %judge %t.aig | %submit %s --name behavioural_SumZeroDet
+RUN: %AIG_TOOL %t.aig -o %t.opt.aig
+RUN: %judge %t.opt.aig | %submit %s --name behavioural_SumZeroDet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,10 +10,11 @@ dependencies = ["lit>=18.0.0", "tabulate>=0.9.0"]
 # Synthesis tool wrappers
 run-circt-synth = "circt_synth_tracker.tools.circt_synth:main"
 run-yosys = "circt_synth_tracker.tools.yosys:main"
-run-abc = "circt_synth_tracker.tools.abc:main"
+run-abc-opt = "circt_synth_tracker.tools.abc_opt:main"
 
 # Utility tools
-aig-judge = "circt_synth_tracker.utils.aig_judge:main"
+mockturtle-aig-judge = "circt_synth_tracker.utils.aig_judge:main"
+abc-aig-judge = "circt_synth_tracker.tools.abc:main"
 submit-results = "circt_synth_tracker.utils.submit:main"
 build-judge = "circt_synth_tracker.utils.judge.build_judge:main"
 

--- a/src/circt_synth_tracker/tools/__init__.py
+++ b/src/circt_synth_tracker/tools/__init__.py
@@ -6,3 +6,56 @@ This module contains wrappers for various synthesis tools:
 - yosys: Yosys-based synthesis
 - abc: ABC-based technology mapping
 """
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_abc(explicit: str | None = None) -> str:
+    """Return the ABC executable to use, in priority order:
+    1. *explicit* path if provided and executable
+    2. ``abc`` on PATH
+    3. ``yosys-abc`` on PATH
+    """
+    candidates = []
+    if explicit:
+        candidates.append(explicit)
+    candidates.extend(("abc", "yosys-abc"))
+    for candidate in candidates:
+        if shutil.which(candidate):
+            return candidate
+    raise FileNotFoundError(
+        "No ABC executable found. Install 'abc' or 'yosys-abc', "
+        "or pass --abc <path>."
+    )
+
+
+def run_abc_commands(
+    input_file: Path,
+    output_file: Path,
+    commands: str,
+    abc_exe: str | None = None,
+) -> None:
+    """Run ABC commands on an AIG file, writing the result to a separate output path.
+
+    Args:
+        input_file:  Path to the input AIGER file.
+        output_file: Path where the optimized AIGER will be written.
+        commands:    Semicolon-separated ABC commands to run (e.g. ``"dc2; dc2;"``).
+        abc_exe:     Explicit path/name hint for the ABC executable. Falls back to
+                     ``abc`` then ``yosys-abc`` when *None* or not found on PATH.
+    """
+    if not commands:
+        return
+
+    abc_exe = find_abc(abc_exe)
+
+    script = f"read {input_file}; {commands}; write {output_file};"
+    print(f"Running ABC commands: {commands}", file=sys.stderr)
+    result = subprocess.run([abc_exe, "-c", script], capture_output=True, text=True)
+    if result.returncode != 0:
+        print("Error during ABC optimization:", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(result.returncode)

--- a/src/circt_synth_tracker/tools/abc_opt.py
+++ b/src/circt_synth_tracker/tools/abc_opt.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+AIG optimization tool for the circt-synth-tracker framework.
+
+Runs optional ABC commands on an AIGER file and writes the result to a
+separate output path.  When no --abc-commands are given the input is copied
+to the output unchanged, making this a transparent no-op in the lit pipeline.
+
+Usage:
+    run-aig-opt input.aig -o output.aig [--abc-commands "dc2; dc2;"] [--abc abc]
+"""
+
+import shutil
+import sys
+import argparse
+from pathlib import Path
+
+from circt_synth_tracker.tools import run_abc_commands
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Optimize an AIGER file using ABC commands",
+        epilog="Without --abc-commands the input is copied to the output unchanged",
+    )
+    parser.add_argument("input", help="Input AIGER file")
+    parser.add_argument("-o", "--output", required=True, help="Output AIGER file")
+    parser.add_argument(
+        "--abc-commands",
+        default="",
+        help="Semicolon-separated ABC commands to run (e.g. 'dc2; dc2;')",
+    )
+    parser.add_argument(
+        "--abc",
+        default=None,
+        help="Path to abc executable (default: auto-detect 'abc' or 'yosys-abc')",
+    )
+
+    args = parser.parse_args()
+
+    input_file = Path(args.input)
+    output_file = Path(args.output)
+
+    if not input_file.exists():
+        print(f"Error: Input file not found: {input_file}", file=sys.stderr)
+        sys.exit(1)
+
+    if args.abc_commands:
+        run_abc_commands(input_file, output_file, args.abc_commands, abc_exe=args.abc)
+    else:
+        shutil.copy2(input_file, output_file)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/circt_synth_tracker/tools/circt_synth.py
+++ b/src/circt_synth_tracker/tools/circt_synth.py
@@ -67,7 +67,6 @@ def main():
         default="",
         help="Additional synthesis options for circt-synth",
     )
-
     args, extra_args = parser.parse_known_args()
 
     input_file = Path(args.input)
@@ -140,7 +139,6 @@ def main():
         print("Step 3: Exporting to AIG...", file=sys.stderr)
         run_command(translate_cmd, "AIG export")
 
-        print(f"  Generated AIG: {output_file}", file=sys.stderr)
         print(f"Success! Generated {output_file}", file=sys.stderr)
 
     finally:


### PR DESCRIPTION
…is and judging

Introduces run-abc-opt and a %AIG_TOOL lit substitution that sits between %SYNTH_TOOL and
  %judge, allowing ABC commands to be applied to the AIG independently of the synthesis tool via
  the ABC_COMMANDS lit parameter. Renames entry points to abc-aig-judge and mockturtle-aig-judge
  for clarity, and adds shared find_abc/run_abc_commands helpers with automatic yosys-abc
  fallback. All benchmark test files are updated to include the %AIG_TOOL step, and CI workflows
  (nightly, PR benchmark, new experiment) expose abc_commands as an input with shared composite
  actions for setup and benchmark execution.

AI-assisted-by: Claude Code (Claude Sonnet 4.6)