### PR TITLE
Rename build-judge to prepare, fetch abc.rc, and update README

### DIFF
--- a/.github/actions/setup-tracker/action.yml
+++ b/.github/actions/setup-tracker/action.yml
@@ -17,4 +17,4 @@ runs:
 
     - name: Build aig-judge
       shell: bash
-      run: uv run build-judge
+      run: uv run prepare

--- a/.github/workflows/ci-pr-benchmark.yml
+++ b/.github/workflows/ci-pr-benchmark.yml
@@ -120,7 +120,7 @@ jobs:
         working-directory: tracker
         run: |
           uv sync
-          uv run build-judge
+          uv run prepare
 
       - name: Checkout CIRCT at PR base SHA
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -4,36 +4,35 @@
 [![Report](https://img.shields.io/badge/report-html-blue)](https://uenoku.github.io/circt-synth-tracker/report.html)
 [![History](https://img.shields.io/badge/history-timeseries-green)](https://uenoku.github.io/circt-synth-tracker/timeseries.html)
 
-NOTE: This repository is a prototype and under active development.
+> **Note:** This repository is a prototype and under active development.
 
-A testing framework for tracking synthesis results for the [Circuit IR and Tools (CIRCT)](https://circt.llvm.org/) project using LLVM lit.
+A testing framework for tracking synthesis quality of the [Circuit IR and Tools (CIRCT)](https://circt.llvm.org/) project using LLVM lit. It runs combinational benchmarks through configurable synthesis and AIG optimization pipelines, then measures area and delay using mockturtle or ABC technology mapping.
 
 ## Prerequisites
-- uv
-- cmake and cpp17-compatible compiler (for building aig-judge)
-- yosys, circt-synth, circt-verilog and circt-translate
+
+- [uv](https://github.com/astral-sh/uv)
+- cmake and a C++17-compatible compiler (for building the mockturtle judge)
+- `yosys`, `circt-synth`, `circt-verilog`, `circt-translate` in PATH
+- `abc` or `yosys-abc` in PATH (for ABC-based judging and AIG optimization)
 
 ## Setup
 
 ```bash
-# Install dependencies
+# Install Python dependencies and build C++ components + fetch abc.rc
 uv sync
-
-# Build C++ components (aig-judge)
-uv run build-judge
+uv run prepare
 
 # Activate the virtual environment
 source .venv/bin/activate
 ```
 
-**Note:** The `aig-judge` tool is a C++ binary that runs AIG technology mapping using mockturtle. It must be built before running tests.
+`uv run prepare` builds the `mockturtle-aig-judge` C++ binary and fetches
+`benchmarks/abc.rc` (ABC's standard alias file) from the ABC repository.
 
 ## Running Tests
 
 ```bash
-
 # Make sure yosys, circt-synth, circt-verilog and circt-translate are in PATH.
-
 # Run all benchmarks
 lit -v benchmarks/ # Test results are stored in build/ by default
 # Run specific test suite
@@ -43,6 +42,8 @@ lit -v benchmarks/comb/DatapathBench/
 lit -v benchmarks/ -DBW=8 -DSYNTH_TOOL=yosys -DTEST_OUTPUT_DIR=build_yosys
 # circt-synth has custom parameters to pass additional arguments
 lit -v benchmarks/ -DSYNTH_TOOL=circt -DCIRCT_SYNTH_EXTRA_ARGS="--disable-datapath"
+# Apply ABC optimization between synthesis and judging
+lit -v benchmarks/ -DABC_COMMANDS="resyn"
 
 # Run specific circt-synth version
 export CIRCT_SYNTH=/path/to/circt-synth
@@ -61,78 +62,119 @@ compare-results circt-summary.json yosys-summary.json
 compare-results circt-summary.json yosys-summary.json -o report.html
 ```
 
-### Available Parameters
+### Available Lit Parameters
 
-These parameters can be set when invoking `lit` using `-D<name>=<value>`:
-- `BW` - Bitwidth for parameterized tests (default: 16)
-- `SYNTH_TOOL` - Synthesis tool to use: `circt` or `yosys` (default: circt)
-- `TEST_OUTPUT_DIR` - Test output directory (default: build)
-- `RESULTS_DIR` - Results storage directory (default: empty, stores in test output dir)
-- `CIRCT_SYNTH_EXTRA_ARGS` - Additional arguments for circt-synth (default: empty)
+| Parameter | Default | Description |
+|---|---|---|
+| `SYNTH_TOOL` | `circt` | Synthesis tool: `circt` or `yosys` |
+| `TECH_MAP` | `mockturtle` | Technology mapper for `%judge`: `mockturtle` or `abc` |
+| `ABC_COMMANDS` | _(empty)_ | ABC commands run via `%AIG_TOOL` between synthesis and judging (e.g. `"compress2rs;"`) |
+| `BW` | `16` | Bitwidth for parameterized benchmarks |
+| `TEST_OUTPUT_DIR` | `build` | Directory for lit test outputs |
+| `CIRCT_SYNTH_EXTRA_ARGS` | _(empty)_ | Extra flags passed to `circt-synth` |
 
-Environment variables for tool paths:
-- `CIRCT_SYNTH`, `CIRCT_VERILOG`, `CIRCT_TRANSLATE` - CIRCT binaries
-- `YOSYS` - Yosys binary
+### Lit Substitutions
 
-Examples:
+| Substitution | Description |
+|---|---|
+| `%SYNTH_TOOL` | Synthesis pipeline (SV → AIG) |
+| `%AIG_TOOL` | AIG optimization layer (`run-abc-opt`); no-op when `ABC_COMMANDS` is empty |
+| `%judge` | AIG evaluation tool (`mockturtle-aig-judge` or `abc-aig-judge`) |
+| `%submit` | Stores benchmark results as JSON |
+| `%BW` | Bitwidth parameter |
+
+### ABC Aliases (`benchmarks/abc.rc`)
+
+After `uv run prepare`, `benchmarks/abc.rc` is populated with ABC's standard
+aliases (fetched from the ABC repository at a pinned commit). These can be
+referenced by name in `ABC_COMMANDS`:
+
 ```bash
-# Run with custom synthesis arguments
-lit -v benchmarks/ -DCIRCT_SYNTH_EXTRA_ARGS="--some-opt --another-flag"
+lit -v benchmarks/ -DABC_COMMANDS="resyn2;"
+lit -v benchmarks/ -DABC_COMMANDS="compress2rs;"
+```
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `CIRCT_SYNTH`, `CIRCT_VERILOG`, `CIRCT_TRANSLATE` | Override CIRCT binary paths |
+| `YOSYS` | Override Yosys binary path |
+| `ABC` | Override ABC binary path |
+
+## Comparing Results
+
+```bash
+# 1. Aggregate results from a test run
+aggregate-results --tool circt --results-dir build -o circt-summary.json
+aggregate-results --tool yosys --results-dir build_yosys -o yosys-summary.json
+
+# 2. Compare and generate a report
+compare-results circt-summary.json yosys-summary.json -o report.html
 ```
 
 ## Project Structure
 
 ```
 circt-synth-tracker/
-├── src/circt_synth_tracker/        # Python package
-│   ├── tools/                      # Synthesis tool wrappers
-│   ├── utils/                      # Utility tools
-│   └── analysis/                   # Analysis tools
-├── benchmarks/comb/                # Combinational logic benchmarks
-│   ├── microbenchmarks/
-│   ├── ELAU/
-│   └── DatapathBench/
-├── lit.cfg.py                      # Top-level lit configuration
-└── pyproject.toml                  # Project configuration
+├── src/circt_synth_tracker/
+│   ├── tools/                  # Synthesis and AIG tool wrappers
+│   │   ├── circt_synth.py      # run-circt-synth
+│   │   ├── yosys.py            # run-yosys
+│   │   ├── abc_opt.py          # run-abc-opt (%AIG_TOOL)
+│   │   └── abc.py              # abc-aig-judge
+│   ├── utils/                  # Judge and submission tools
+│   │   └── judge/              # mockturtle-aig-judge C++ build
+│   └── analysis/               # Aggregation and reporting tools
+├── benchmarks/
+│   ├── abc.rc                  # ABC aliases (fetched by `prepare`)
+│   ├── lit.cfg.py              # Top-level lit configuration
+│   └── comb/
+│       ├── microbenchmarks/    # Small inline SV benchmarks
+│       ├── ELAU/               # ELAU arithmetic library benchmarks
+│       └── DatapathBench/      # Datapath-oriented benchmarks
+└── pyproject.toml
 ```
 
-### Available Substitutions
+## CI Workflows
 
-- `%SYNTH_TOOL` - Selected synthesis tool
-- `%BW` - Bitwidth parameter
-- `%judge` - AIG evaluation tool
-- `%submit` - Results submission tool
+### Nightly (`ci-nightly.yml`)
+Runs daily against the latest CIRCT nightly build. Compares CIRCT vs Yosys
+across configured bitwidths, publishes HTML reports and time series to GitHub Pages.
 
-## Benchmark Suites
+Supports optional `abc_commands` input to apply ABC optimization via `%AIG_TOOL`.
 
-### Microbenchmarks (`benchmarks/comb/microbenchmarks/`)
-Small combinational logic tests for basic operations.
+### PR Benchmark (`ci-pr-benchmark.yml`)
+Triggered manually (or via `@tracker-bot check-pr <N>` comment) to benchmark
+a specific CIRCT PR. Builds CIRCT from source at the PR base and head SHAs,
+runs benchmarks, and posts a before/after comparison.
 
-### ELAU (`benchmarks/comb/ELAU/`)
-Arithmetic benchmarks from the ELAU library. Tests are auto-generated using `generate_tests.py`.
+Supports optional `abc_commands` input.
 
-### DatapathBench (`benchmarks/comb/DatapathBench/`)
-Datapath-oriented benchmarks.
+### Experiment (`ci-experiment.yml`)
+Triggered manually to compare two arbitrary configurations side by side.
+Each configuration independently specifies:
+- `synth_tool`: `circt` or `yosys`
+- `abc_commands`: ABC optimization script
+- `circt_synth_extra_args`: extra flags for `circt-synth`
+
+Useful for evaluating the effect of ABC passes, synthesis options, or tool choice.
+
+### PR Bot (`ci-pr-bot.yml`)
+Listens for `@tracker-bot check-pr <N>` comments on issues and dispatches
+the PR benchmark workflow automatically.
 
 ## Time Series Tracking
 
-The CI runs nightly and publishes a historical report to GitHub Pages at
-[timeseries.html](https://uenoku.github.io/circt-synth-tracker/timeseries.html).
-It shows geo-mean trends for gates, depth, area (ASAP7), and delay (ASAP7)
-for both CIRCT and Yosys over the past 90 days, plus per-benchmark detail
-selectable via a dropdown.
+The nightly CI publishes a rolling 90-day history to GitHub Pages:
+- [report.html](https://uenoku.github.io/circt-synth-tracker/report.html) — latest comparison
+- [timeseries.html](https://uenoku.github.io/circt-synth-tracker/timeseries.html) — geo-mean trends
+- [history.json](https://uenoku.github.io/circt-synth-tracker/history.json) — raw data
 
-The raw history data is available at
-[history.json](https://uenoku.github.io/circt-synth-tracker/history.json).
-
-To generate a local time series report from past data:
-
+To generate a local time series report:
 ```bash
-# Build history from existing summary files (one per day)
 append-history --circt circt-summary.json --yosys yosys-summary.json \
-               -o history.json --date 2026-02-16
-
-# Generate interactive HTML report
+               -o history.json
 timeseries-report history.json -o timeseries.html
 ```
 
@@ -140,14 +182,16 @@ timeseries-report history.json -o timeseries.html
 
 Installed via `uv sync`:
 
-**Synthesis:**
-- `run-circt-synth` - CIRCT pipeline (circt-verilog → circt-synth → circt-translate)
-- `run-yosys` - Yosys wrapper with unified interface
-
-**Analysis:**
-- `aig-judge` - Evaluate AIG files (outputs JSON)
-- `submit-results` - Store benchmark results as JSON
-- `aggregate-results` - Aggregate results into summaries
-- `compare-results` - Compare results across tools, generate HTML/Markdown/JSON reports
-- `append-history` - Append a day's summaries to a cumulative `history.json`
-- `timeseries-report` - Generate an interactive HTML time series report from `history.json`
+| Tool | Description |
+|---|---|
+| `run-circt-synth` | CIRCT pipeline: circt-verilog → circt-synth → circt-translate → AIG |
+| `run-yosys` | Yosys wrapper producing AIG output |
+| `run-abc-opt` | AIG optimizer using ABC commands and `abc.rc` aliases (`%AIG_TOOL`) |
+| `mockturtle-aig-judge` | Evaluate AIG with mockturtle (ASAP7 + Sky130) |
+| `abc-aig-judge` | Evaluate AIG with ABC technology mapping (ASAP7 + Sky130) |
+| `submit-results` | Store benchmark result JSON |
+| `aggregate-results` | Aggregate per-benchmark JSONs into a summary |
+| `compare-results` | Compare two summaries; output HTML / Markdown / JSON |
+| `append-history` | Append a day's summaries to `history.json` |
+| `timeseries-report` | Generate interactive HTML time series from `history.json` |
+| `prepare` | Build `mockturtle-aig-judge` and fetch `benchmarks/abc.rc` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ mockturtle-aig-judge = "circt_synth_tracker.utils.aig_judge:main"
 abc-aig-judge = "circt_synth_tracker.tools.abc:main"
 submit-results = "circt_synth_tracker.utils.submit:main"
 build-judge = "circt_synth_tracker.utils.judge.build_judge:main"
+prepare = "circt_synth_tracker.utils.judge.build_judge:main"
 
 # Analysis tools
 aggregate-results = "circt_synth_tracker.analysis.aggregate_results:main"

--- a/src/circt_synth_tracker/tools/abc_opt.py
+++ b/src/circt_synth_tracker/tools/abc_opt.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 """
-AIG optimization tool for the circt-synth-tracker framework.
+run-abc-opt: Optimize an AIGER file using ABC commands.
 
 Runs optional ABC commands on an AIGER file and writes the result to a
 separate output path.  When no --abc-commands are given the input is copied
 to the output unchanged, making this a transparent no-op in the lit pipeline.
 
+An abc.rc file is auto-loaded from the benchmarks/ directory if present,
+allowing aliases to be defined and referenced in --abc-commands.
+
 Usage:
-    run-aig-opt input.aig -o output.aig [--abc-commands "dc2; dc2;"] [--abc abc]
+    run-abc-opt input.aig -o output.aig [--abc-commands "compress2rs;"] [--abc abc]
 """
 
 import shutil
@@ -16,6 +19,10 @@ import argparse
 from pathlib import Path
 
 from circt_synth_tracker.tools import run_abc_commands
+
+# Auto-detect abc.rc relative to the project root (benchmarks/abc.rc)
+_PROJECT_ROOT = Path(__file__).parent.parent.parent.parent
+DEFAULT_ABC_RC = _PROJECT_ROOT / "benchmarks" / "abc.rc"
 
 
 def main():
@@ -28,12 +35,17 @@ def main():
     parser.add_argument(
         "--abc-commands",
         default="",
-        help="Semicolon-separated ABC commands to run (e.g. 'dc2; dc2;')",
+        help="Semicolon-separated ABC commands to run (e.g. 'compress2rs;')",
     )
     parser.add_argument(
         "--abc",
         default=None,
         help="Path to abc executable (default: auto-detect 'abc' or 'yosys-abc')",
+    )
+    parser.add_argument(
+        "--abc-rc",
+        default=None,
+        help=f"ABC script file loaded via -F before commands (default: {DEFAULT_ABC_RC} if it exists)",
     )
 
     args = parser.parse_args()
@@ -45,8 +57,16 @@ def main():
         print(f"Error: Input file not found: {input_file}", file=sys.stderr)
         sys.exit(1)
 
+    # Resolve rc file: explicit arg > auto-detected default
+    rc_file = Path(args.abc_rc) if args.abc_rc else DEFAULT_ABC_RC
+    if rc_file.exists():
+        print(f"Loading ABC rc file: {rc_file}", file=sys.stderr)
+    else:
+        rc_file = None
+
     if args.abc_commands:
-        run_abc_commands(input_file, output_file, args.abc_commands, abc_exe=args.abc)
+        run_abc_commands(input_file, output_file, args.abc_commands,
+                         abc_exe=args.abc, rc_file=rc_file)
     else:
         shutil.copy2(input_file, output_file)
 

--- a/src/circt_synth_tracker/utils/aig_judge.py
+++ b/src/circt_synth_tracker/utils/aig_judge.py
@@ -48,7 +48,7 @@ def main():
     binary = find_binary()
     if not binary:
         print(
-            "Error: aig-judge binary not found. Please run 'uv run build-judge' first.",
+            "Error: aig-judge binary not found. Please run 'uv run prepare' (or 'uv run build-judge') first.",
             file=sys.stderr,
         )
         return 1

--- a/src/circt_synth_tracker/utils/judge/build_judge.py
+++ b/src/circt_synth_tracker/utils/judge/build_judge.py
@@ -3,7 +3,13 @@
 
 import subprocess
 import sys
+import urllib.request
 from pathlib import Path
+
+# Pinned to a specific commit for reproducibility.
+# To update: check https://github.com/berkeley-abc/abc/commits/master/abc.rc
+ABC_RC_COMMIT = "daf3313ce6c122e8fada8b14b089222d17aecd8e"
+ABC_RC_URL = f"https://raw.githubusercontent.com/berkeley-abc/abc/{ABC_RC_COMMIT}/abc.rc"
 
 
 def main():
@@ -52,14 +58,25 @@ def main():
 
     # Check if binary was created
     binary_path = build_dir / "aig-judge"
-    if binary_path.exists():
-        print("\n[3/3] Build successful!")
-        print(f"Binary location: {binary_path}")
-        print("=" * 60)
-        return 0
-    else:
+    if not binary_path.exists():
         print("\nError: Binary not found after build", file=sys.stderr)
         return 1
+
+    print("\n[3/3] Build successful!")
+    print(f"Binary location: {binary_path}")
+
+    # Fetch abc.rc from the ABC repository
+    abc_rc_path = project_root / "benchmarks" / "abc.rc"
+    print(f"\n[4/4] Fetching abc.rc from ABC repository...")
+    try:
+        urllib.request.urlretrieve(ABC_RC_URL, abc_rc_path)
+        print(f"abc.rc saved to: {abc_rc_path}")
+    except Exception as e:
+        print(f"Warning: Failed to fetch abc.rc: {e}", file=sys.stderr)
+        print("ABC aliases will not be available for run-abc-opt.", file=sys.stderr)
+
+    print("=" * 60)
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The prepare command now also fetches benchmarks/abc.rc from the ABC repository at a pinned commit, making standard aliases (resyn2, compress2rs, etc.) available to run-abc-opt without manual setup. Updated README to document all recent additions: %AIG_TOOL, ABC_COMMANDS, TECH_MAP, abc.rc aliases, CI workflows (experiment, PR bot), and the full command-line tool table.

AI-assisted-by: Claude Sonnet 4.6