### PR TITLE
Add translation validation via circt-lec per-pass checking

### DIFF
--- a/.github/actions/run-benchmark/action.yml
+++ b/.github/actions/run-benchmark/action.yml
@@ -41,13 +41,17 @@ runs:
         [ -n "${{ inputs.abc_commands }}" ] && ABC_PARAM="-DABC_COMMANDS=\"${{ inputs.abc_commands }}\""
         EXTRA_PARAM=""
         [ -n "${{ inputs.circt_synth_extra_args }}" ] && EXTRA_PARAM="-DCIRCT_SYNTH_EXTRA_ARGS=\"${{ inputs.circt_synth_extra_args }}\""
+        TV_PARAM=""
+        if [ "${{ inputs.synth_tool }}" = "circt" ]; then
+          TV_PARAM="-DRUN_TV=1 -DTV_SOLVER=bitwuzla"
+        fi
         IFS=',' read -ra BWS <<< "${{ inputs.bitwidths }}"
         for BW in "${BWS[@]}"; do
           eval lit -v benchmarks/ \
             -DSYNTH_TOOL=${{ inputs.synth_tool }} \
             -DTEST_OUTPUT_DIR=${{ inputs.output_dir }} \
             -DBW=$BW \
-            $ABC_PARAM $EXTRA_PARAM || true
+            $ABC_PARAM $EXTRA_PARAM $TV_PARAM || true
         done
 
     - name: Aggregate results

--- a/.github/actions/setup-tracker/action.yml
+++ b/.github/actions/setup-tracker/action.yml
@@ -18,3 +18,7 @@ runs:
     - name: Build aig-judge
       shell: bash
       run: uv run prepare
+
+    - name: Download Bitwuzla
+      shell: bash
+      run: bash .github/scripts/install-bitwuzla.sh

--- a/.github/scripts/install-bitwuzla.sh
+++ b/.github/scripts/install-bitwuzla.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Download and install the latest Bitwuzla static binary to /usr/local/bin.
+set -euo pipefail
+
+apt-get install -y unzip
+BITWUZLA_VERSION=$(curl -s https://api.github.com/repos/bitwuzla/bitwuzla/releases/latest | jq -r '.tag_name')
+curl -fsSL "https://github.com/bitwuzla/bitwuzla/releases/download/${BITWUZLA_VERSION}/Bitwuzla-Linux-x86_64-static.zip" \
+  -o bitwuzla.zip
+unzip -j bitwuzla.zip '*/bin/bitwuzla' -d /usr/local/bin/
+rm bitwuzla.zip
+chmod +x /usr/local/bin/bitwuzla
+bitwuzla --version

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -84,14 +84,6 @@ jobs:
 
       - name: Determine equiv-check flag
         run: |
-          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "pull_request" ] || [ "${{ inputs.equiv_check }}" = "true" ]; then
-            echo "EQUIV_CHECK=true" >> $GITHUB_ENV
-          else
-            echo "EQUIV_CHECK=false" >> $GITHUB_ENV
-          fi
-
-      - name: Determine equiv-check flag
-        run: |
           if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "push" ] || [ "${{ inputs.equiv_check }}" = "true" ]; then
             echo "EQUIV_CHECK=true" >> $GITHUB_ENV
           else

--- a/.github/workflows/ci-pr-benchmark.yml
+++ b/.github/workflows/ci-pr-benchmark.yml
@@ -127,6 +127,9 @@ jobs:
           uv sync
           uv run prepare
 
+      - name: Download Bitwuzla
+        run: bash tracker/.github/scripts/install-bitwuzla.sh
+
       - name: Checkout CIRCT at PR base SHA
         uses: actions/checkout@v4
         with:
@@ -166,7 +169,8 @@ jobs:
           IFS=',' read -ra BWS <<< "${{ inputs.bitwidths || '16,48' }}"
           for BW in "${BWS[@]}"; do
             lit -v benchmarks/ -DSYNTH_TOOL=circt \
-              -DTEST_OUTPUT_DIR=build_before -DBW=$BW $ABC_PARAM || true
+              -DTEST_OUTPUT_DIR=build_before -DBW=$BW $ABC_PARAM \
+              -DRUN_TV=1 -DTV_SOLVER=bitwuzla || true
           done
           aggregate-results --tool "base" --version "$BEFORE_VERSION" \
             --results-dir build_before -o before-summary.json
@@ -210,7 +214,8 @@ jobs:
           IFS=',' read -ra BWS <<< "${{ inputs.bitwidths || '16,48' }}"
           for BW in "${BWS[@]}"; do
             lit -v benchmarks/ -DSYNTH_TOOL=circt \
-              -DTEST_OUTPUT_DIR=build_after -DBW=$BW $ABC_PARAM || true
+              -DTEST_OUTPUT_DIR=build_after -DBW=$BW $ABC_PARAM \
+              -DRUN_TV=1 -DTV_SOLVER=bitwuzla || true
           done
           aggregate-results --tool "pr" --version "$AFTER_VERSION" \
             --results-dir build_after -o after-summary.json

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ lit -v benchmarks/ -DSYNTH_TOOL=circt -DCIRCT_SYNTH_EXTRA_ARGS="--disable-datapa
 # Apply ABC optimization between synthesis and judging
 lit -v benchmarks/ -DABC_COMMANDS="resyn"
 
+# Run SMT Translation Validation (TV) with Bitwuzla
+# TV verifies each CIRCT synthesis pass preserves circuit semantics using circt-lec + Bitwuzla
+lit -v benchmarks/ -DRUN_TV=1 -DTV_SOLVER=bitwuzla
+
 # Run specific circt-synth version
 export CIRCT_SYNTH=/path/to/circt-synth
 lit -v benchmarks/
@@ -82,6 +86,8 @@ compare-results circt-summary.json yosys-summary.json -o report.html --equiv-che
 | `BW` | `16` | Bitwidth for parameterized benchmarks |
 | `TEST_OUTPUT_DIR` | `build` | Directory for lit test outputs |
 | `CIRCT_SYNTH_EXTRA_ARGS` | _(empty)_ | Extra flags passed to `circt-synth` |
+| `RUN_TV` | _(empty)_ | Enable SMT Translation Validation; set to `1` to enable |
+| `TV_SOLVER` | _(empty)_ | SMT solver command for TV (e.g. `bitwuzla`, `z3 -in`); uses `circt-lec --run` if unset |
 
 ### Lit Substitutions
 
@@ -126,6 +132,35 @@ check-cec circt-summary.json yosys-summary.json -o cec.json
 compare-results circt-summary.json yosys-summary.json -o report.html --cec cec.json
 ```
 
+## SMT Translation Validation
+
+Translation Validation (TV) uses `circt-lec` to verify that each CIRCT synthesis pass preserves the circuit's logical equivalence. When enabled, `circt-synth` dumps per-pass MLIR snapshots and `circt-lec` checks each consecutive pair in the transformation sequence:
+
+```
+input.mlir → pass_0 → pass_1 → … → synth_output.mlir
+```
+
+Each step is checked independently. Results are recorded as a `.tv` sidecar file alongside the AIG output and aggregated into the summary JSON under `tv_status` (`pass` / `fail` / `error`) and `tv_results` (per-step status).
+
+### Running TV locally
+
+TV requires `circt-lec` in PATH. Use [Bitwuzla](https://bitwuzla.github.io/) as the SMT solver for best performance:
+
+```bash
+# Download Bitwuzla (static binary, Linux x86_64)
+curl -fsSL https://github.com/bitwuzla/bitwuzla/releases/latest/download/Bitwuzla-Linux-x86_64-static.zip \
+  | unzip -j - '*/bin/bitwuzla' -d ~/.local/bin/
+
+# Run benchmarks with TV
+lit -v benchmarks/ -DSYNTH_TOOL=circt -DRUN_TV=1 -DTV_SOLVER=bitwuzla
+```
+
+TV results appear in the HTML report as an **SMT TV (bitwuzla)** column and in the Markdown report under a **SMT Translation Validation (bitwuzla)** summary section with per-benchmark pass/fail counts and a per-transformation step table in the details.
+
+### TV in CI
+
+TV runs automatically for all CIRCT benchmark runs in CI (nightly, PR benchmark, and experiment workflows). Bitwuzla is downloaded as a static binary during setup.
+
 ## Project Structure
 
 ```
@@ -159,6 +194,8 @@ Supports optional inputs:
 - `abc_commands`: apply ABC optimization via `%AIG_TOOL`
 - `equiv_check`: run combinational equivalence check (CEC) via `check-cec`
 
+SMT Translation Validation runs automatically for CIRCT using Bitwuzla.
+
 ### PR Benchmark (`ci-pr-benchmark.yml`)
 Triggered manually (or via `@tracker-bot check-pr <N>` comment) to benchmark
 a specific CIRCT PR. Builds CIRCT from source at the PR base and head SHAs,
@@ -167,6 +204,8 @@ runs benchmarks, and posts a before/after comparison.
 Supports optional inputs:
 - `abc_commands`: apply ABC optimization
 - `equiv_check`: run CEC between the before/after AIG outputs
+
+SMT Translation Validation runs automatically on both the base and head builds using Bitwuzla.
 
 ### Experiment (`ci-experiment.yml`)
 Triggered manually to compare two arbitrary configurations side by side.

--- a/benchmarks/lit.cfg.py
+++ b/benchmarks/lit.cfg.py
@@ -52,12 +52,18 @@ filecheck = registry.get_tool('FileCheck').get_command()
 circt_synth_extra_args = lit_config.params.get('CIRCT_SYNTH_EXTRA_ARGS', '')
 abc_commands = lit_config.params.get('ABC_COMMANDS', '')
 run_lec = lit_config.params.get('RUN_LEC', '')
+run_tv = lit_config.params.get('RUN_TV', '')
+tv_solver = lit_config.params.get('TV_SOLVER', '')
 
 circt_synth_wrapper = f'run-circt-synth --circt-synth {circt_synth} --circt-verilog {circt_verilog} --circt-translate {circt_translate} --circt-lec {circt_lec}'
 if circt_synth_extra_args:
     circt_synth_wrapper += f' --circt-synth-extra-args=\"{circt_synth_extra_args}\"'
 if run_lec:
     circt_synth_wrapper += ' --run-lec'
+if run_tv:
+    circt_synth_wrapper += ' --run-tv'
+if tv_solver:
+    circt_synth_wrapper += f' --tv-solver=\"{tv_solver}\"'
 
 yosys_wrapper = f'run-yosys --yosys {yosys}'
 

--- a/src/circt_synth_tracker/analysis/aggregate_results.py
+++ b/src/circt_synth_tracker/analysis/aggregate_results.py
@@ -99,6 +99,31 @@ def main():
                                 pass
                             break
 
+                # Merge TV (translation validation) sidecar if present (<aig>.tv).
+                if aig_path:
+                    tv_candidates = [Path(aig_path + ".tv")]
+                    inner = Path(aig_path).stem
+                    if "." in inner:
+                        base = inner.rsplit(".", 1)[0]
+                        tv_candidates.append(Path(aig_path).parent / (base + Path(aig_path).suffix + ".tv"))
+                    for tv_sidecar in tv_candidates:
+                        if tv_sidecar.exists():
+                            try:
+                                import json as _json
+                                tv_data = _json.loads(tv_sidecar.read_text())
+                                if "tv_status" in tv_data:
+                                    metrics["tv_status"] = tv_data["tv_status"]
+                                tv_results = tv_data.get("tv_results", [])
+                                if tv_results:
+                                    metrics["tv_total"] = len(tv_results)
+                                    metrics["tv_verified"] = sum(
+                                        1 for r in tv_results if r.get("status") == "equiv"
+                                    )
+                                    metrics["tv_results"] = tv_results
+                            except Exception:
+                                pass
+                            break
+
                 results[benchmark_name] = metrics
 
                 if args.verbose:

--- a/src/circt_synth_tracker/analysis/compare_results.py
+++ b/src/circt_synth_tracker/analysis/compare_results.py
@@ -754,6 +754,33 @@ def generate_html_report(summaries, all_benchmarks, output_path, timeseries_url=
             border-radius: 6px;
             padding: 16px;
         }
+        .tv-cell {
+            position: relative;
+            text-align: center;
+            cursor: default;
+        }
+        .tv-cell .tv-tip {
+            display: none;
+            position: absolute;
+            z-index: 100;
+            left: 50%;
+            top: 100%;
+            transform: translateX(-50%);
+            background: #333;
+            color: #fff;
+            font-size: 11px;
+            font-family: 'Courier New', monospace;
+            white-space: pre;
+            padding: 6px 10px;
+            border-radius: 4px;
+            box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+            pointer-events: none;
+            min-width: 200px;
+            text-align: left;
+        }
+        .tv-cell:hover .tv-tip {
+            display: block;
+        }
     </style>
     <script>
         function copyGeomeanAsMarkdown() {
@@ -877,18 +904,18 @@ def generate_html_report(summaries, all_benchmarks, output_path, timeseries_url=
                     <th>Benchmark</th>
 """
 
-    # Determine which tools have LEC data
-    tools_with_lec = [
+    # Determine which tools have TV (translation validation) data
+    tools_with_tv = [
         t for t in tool_names
         if any(
-            summaries[t].get("benchmarks", {}).get(b, {}).get("lec_status")
+            summaries[t].get("benchmarks", {}).get(b, {}).get("tv_status")
             for b in all_benchmarks
         )
     ]
 
     # Add headers for each tool
     for tool in tool_names:
-        colspan = 8 if tool in tools_with_lec else 7
+        colspan = 7 if tool in tools_with_tv else 6
         html += f"                    <th class='tool-column' colspan='{colspan}'>{escape(tool)}</th>\n"
     if equiv_results is not None:
         html += "                    <th>CEC</th>\n"
@@ -901,9 +928,9 @@ def generate_html_report(summaries, all_benchmarks, output_path, timeseries_url=
 
     # Sub-headers for metrics
     for tool in tool_names:
-        html += "                    <th class='metric'>Gates</th><th class='metric'>Depth</th><th class='metric'>Area (ASAP7)</th><th class='metric'>Delay (ASAP7)</th><th class='metric'>Area (Sky130)</th><th class='metric'>Delay (Sky130)</th><th class='metric'>Runtime</th>\n"
-        if tool in tools_with_lec:
-            html += "                    <th class='metric'>SMT CEC</th>\n"
+        html += "                    <th class='metric'>Gates</th><th class='metric'>Depth</th><th class='metric'>Area (ASAP7)</th><th class='metric'>Delay (ASAP7)</th><th class='metric'>Area (Sky130)</th><th class='metric'>Delay (Sky130)</th>\n"
+        if tool in tools_with_tv:
+            html += "                    <th class='metric'>SMT TV (bitwuzla)</th>\n"
     if equiv_results is not None:
         html += "                    <th></th>\n"
 
@@ -916,7 +943,7 @@ def generate_html_report(summaries, all_benchmarks, output_path, timeseries_url=
     # Add rows for each benchmark, grouped by category
     for category in sorted_categories:
         # Add category header row
-        num_columns = 1 + (len(tool_names) * 7) + len(tools_with_lec)
+        num_columns = 1 + (len(tool_names) * 6) + len(tools_with_tv)
         if equiv_results is not None:
             num_columns += 1
         html += "                <tr>\n"
@@ -947,8 +974,6 @@ def generate_html_report(summaries, all_benchmarks, output_path, timeseries_url=
             baseline_delay_asap7 = baseline_result.get("delay_asap7", 0)
             baseline_area_sky130 = baseline_result.get("area_sky130", 0)
             baseline_delay_sky130 = baseline_result.get("delay_sky130", 0)
-            baseline_runtime = baseline_result.get("runtime_ms", 0)
-
             for tool in tool_names:
                 result = comparison.get(tool, {})
                 gates = result.get("gates", "N/A")
@@ -957,7 +982,6 @@ def generate_html_report(summaries, all_benchmarks, output_path, timeseries_url=
                 delay_asap7 = result.get("delay_asap7", "N/A")
                 area_sky130 = result.get("area_sky130", "N/A")
                 delay_sky130 = result.get("delay_sky130", "N/A")
-                runtime = result.get("runtime_ms", "N/A")
 
                 # Helper function to format metric with percentage and background color
                 def format_metric(value, baseline, lower_is_better=True):
@@ -1031,31 +1055,46 @@ def generate_html_report(summaries, all_benchmarks, output_path, timeseries_url=
                 delay_sky130_content, delay_sky130_style = format_metric(
                     delay_sky130, baseline_delay_sky130, lower_is_better=True
                 )
-                runtime_content, runtime_style = format_metric(
-                    runtime, baseline_runtime, lower_is_better=True
-                )
-
                 html += f"                    <td class='metric'{gates_style}>{gates_content}</td>\n"
                 html += f"                    <td class='metric'{depth_style}>{depth_content}</td>\n"
                 html += f"                    <td class='metric'{area_asap7_style}>{area_asap7_content}</td>\n"
                 html += f"                    <td class='metric'{delay_asap7_style}>{delay_asap7_content}</td>\n"
                 html += f"                    <td class='metric'{area_sky130_style}>{area_sky130_content}</td>\n"
                 html += f"                    <td class='metric'{delay_sky130_style}>{delay_sky130_content}</td>\n"
-                html += f"                    <td class='metric'{runtime_style}>{runtime_content}</td>\n"
 
-                if tool in tools_with_lec:
-                    lec_status = result.get("lec_status")
-                    if lec_status == "equiv":
-                        lec_cell = "<td style='text-align:center; background:rgb(200,255,200)'>✔ EQUIV</td>"
-                    elif lec_status == "non-equiv":
-                        lec_cell = "<td style='text-align:center; background:rgb(255,200,200)'>✘ NON-EQUIV</td>"
-                    elif lec_status == "timeout":
-                        lec_cell = "<td style='text-align:center; background:rgb(255,235,180)'>TIMEOUT</td>"
-                    elif lec_status == "error":
-                        lec_cell = "<td style='text-align:center; background:rgb(255,235,180)'>TOOL ERROR</td>"
+                if tool in tools_with_tv:
+                    tv_status = result.get("tv_status")
+                    tv_verified = result.get("tv_verified")
+                    tv_total = result.get("tv_total")
+                    tv_results_list = result.get("tv_results", [])
+                    frac = f" {tv_verified}/{tv_total}" if tv_verified is not None and tv_total is not None else ""
+                    has_timeout = any(r.get("status") in ("timeout", "error") for r in tv_results_list)
+
+                    def _tv_tip_span(header, results):
+                        if not results:
+                            return f"<span class='tv-tip'>{escape(header)}</span>"
+                        icons = {"equiv": "✔", "non-equiv": "✘", "timeout": "⏱", "error": "⚠"}
+                        lines = header + "\n" + "\n".join(
+                            f"{icons.get(r['status'], '?')} {r['from']} → {r['to']}"
+                            for r in results
+                        )
+                        return f"<span class='tv-tip'>{escape(lines)}</span>"
+
+                    if tv_status == "pass" and not has_timeout:
+                        header = f"All {tv_total} transformations verified equiv"
+                        tv_cell = f"<td class='tv-cell' style='background:rgb(200,255,200)'>✔{frac}{_tv_tip_span(header, tv_results_list)}</td>"
+                    elif tv_status == "pass":  # pass but with timeouts
+                        header = f"Partially verified ({tv_verified}/{tv_total} equiv, rest timed out)"
+                        tv_cell = f"<td class='tv-cell' style='background:rgb(255,235,180)'>~{frac}{_tv_tip_span(header, tv_results_list)}</td>"
+                    elif tv_status == "fail":
+                        header = f"NON-EQUIV detected ({tv_verified}/{tv_total} equiv)"
+                        tv_cell = f"<td class='tv-cell' style='background:rgb(255,200,200)'>✘ NON-EQUIV{frac}{_tv_tip_span(header, tv_results_list)}</td>"
+                    elif tv_status == "error":
+                        header = f"Tool error ({tv_verified}/{tv_total} equiv)"
+                        tv_cell = f"<td class='tv-cell' style='background:rgb(255,235,180)'>⚠{frac}{_tv_tip_span(header, tv_results_list)}</td>"
                     else:
-                        lec_cell = "<td style='text-align:center; color:#aaa'>—</td>"
-                    html += f"                    {lec_cell}\n"
+                        tv_cell = "<td style='text-align:center; color:#aaa'>—</td>"
+                    html += f"                    {tv_cell}\n"
 
             if equiv_results is not None:
                 status = equiv_results.get(benchmark_name)
@@ -1436,6 +1475,27 @@ def generate_markdown_report(summaries, all_benchmarks, output_path, equiv_resul
         markdown += "### Summary (Geometric Mean)\n\n"
         markdown += geomean_table + "\n\n"
 
+    # SMT TV summary
+    all_tv_statuses = [
+        summary.get("benchmarks", {}).get(bname, {}).get("tv_status")
+        for summary in summaries.values()
+        for bname in all_benchmarks
+        if summary.get("benchmarks", {}).get(bname, {}).get("tv_status") is not None
+    ]
+    if all_tv_statuses:
+        n_tv_pass  = all_tv_statuses.count("pass")
+        n_tv_fail  = all_tv_statuses.count("fail")
+        n_tv_error = all_tv_statuses.count("error")
+        markdown += "### SMT Translation Validation (bitwuzla)\n\n"
+        markdown += f"✔ Pass: {n_tv_pass} | ✘ Fail: {n_tv_fail} | ⚠ Error: {n_tv_error}\n\n"
+        failed_tv = sorted(
+            bname for summary in summaries.values()
+            for bname, bd in summary.get("benchmarks", {}).items()
+            if bd.get("tv_status") == "fail"
+        )
+        if failed_tv:
+            markdown += "**Non-equivalent (TV):** " + ", ".join(f"`{n}`" for n in failed_tv) + "\n\n"
+
     # CEC summary
     if equiv_results:
         n_equiv   = sum(1 for s in equiv_results.values() if s == "equiv")
@@ -1474,11 +1534,17 @@ def generate_markdown_report(summaries, all_benchmarks, output_path, equiv_resul
                 sign = "+" if diff_pct > 0 else ""
                 return f"{value} ({sign}{diff_pct:.1f}%)"
 
-            headers = ["Tool", "Gates", "Depth", "Area (ASAP7)", "Delay (ASAP7)", "Area (Sky130)", "Delay (Sky130)", "Runtime"]
+            tools_with_tv_md = [
+                t for t in tool_names
+                if comparison.get(t, {}).get("tv_status") is not None
+            ]
+            headers = ["Tool", "Gates", "Depth", "Area (ASAP7)", "Delay (ASAP7)", "Area (Sky130)", "Delay (Sky130)"]
+            if tools_with_tv_md:
+                headers.append("SMT TV (bitwuzla)")
             rows = []
             for tool in tool_names:
                 result = comparison.get(tool, {})
-                rows.append([
+                row = [
                     tool,
                     fmt(result.get("gates"),        baseline_result.get("gates"),        tool),
                     fmt(result.get("depth"),        baseline_result.get("depth"),        tool),
@@ -1486,8 +1552,12 @@ def generate_markdown_report(summaries, all_benchmarks, output_path, equiv_resul
                     fmt(result.get("delay_asap7"),  baseline_result.get("delay_asap7"),  tool),
                     fmt(result.get("area_sky130"),  baseline_result.get("area_sky130"),  tool),
                     fmt(result.get("delay_sky130"), baseline_result.get("delay_sky130"), tool),
-                    fmt(result.get("runtime_ms"),   baseline_result.get("runtime_ms"),   tool),
-                ])
+                ]
+                if tools_with_tv_md:
+                    tv_status = result.get("tv_status")
+                    tv_icons = {"pass": "✔", "fail": "✘", "error": "⚠", None: "—"}
+                    row.append(tv_icons.get(tv_status, tv_status or "—"))
+                rows.append(row)
 
             cec_status = ""
             if equiv_results and bname in equiv_results:
@@ -1497,6 +1567,24 @@ def generate_markdown_report(summaries, all_benchmarks, output_path, equiv_resul
 
             detail_lines.append(f"\n**{bname}**{cec_status}\n\n")
             detail_lines.append(tabulate(rows, headers=headers, tablefmt="github") + "\n")
+
+            # Per-transformation TV detail
+            tv_step_icons = {"equiv": "✔", "non-equiv": "✘", "timeout": "⏱", "error": "⚠"}
+            for tool in tools_with_tv_md:
+                tv_results_list = comparison.get(tool, {}).get("tv_results", [])
+                if tv_results_list:
+                    detail_lines.append(f"\n_SMT Translation Validation ({tool})_\n\n")
+                    tv_rows = [
+                        [
+                            tv_step_icons.get(r["status"], r["status"]),
+                            r["from"],
+                            r["to"],
+                        ]
+                        for r in tv_results_list
+                    ]
+                    detail_lines.append(
+                        tabulate(tv_rows, headers=["", "From", "To"], tablefmt="github") + "\n"
+                    )
 
     if detail_lines:
         markdown += "<details>\n<summary>Per-benchmark details</summary>\n"
@@ -1545,7 +1633,6 @@ def display_table(comparison, metric_filter=None):
         "Delay (ASAP7)",
         "Area (Sky130)",
         "Delay (Sky130)",
-        "Runtime (ms)",
     ]
     rows = []
 
@@ -1561,7 +1648,6 @@ def display_table(comparison, metric_filter=None):
             result.get("delay_asap7", "N/A"),
             result.get("area_sky130", "N/A"),
             result.get("delay_sky130", "N/A"),
-            result.get("runtime_ms", "N/A"),
         ]
         rows.append(row)
 
@@ -1592,7 +1678,6 @@ def display_differences(comparison):
         ("delay_asap7", "delay (ASAP7)"),
         ("area_sky130", "area (sky130)"),
         ("delay_sky130", "delay (sky130)"),
-        ("runtime_ms", "runtime_ms"),
     ]
 
     for metric_key, metric_display in metrics:
@@ -1631,7 +1716,6 @@ def display_markdown(comparison, metric_filter=None):
         "Delay (ASAP7)",
         "Area (Sky130)",
         "Delay (Sky130)",
-        "Runtime",
     ]
     rows = []
 
@@ -1644,7 +1728,6 @@ def display_markdown(comparison, metric_filter=None):
     baseline_delay_asap7 = baseline_result.get("delay_asap7", 0)
     baseline_area_sky130 = baseline_result.get("area_sky130", 0)
     baseline_delay_sky130 = baseline_result.get("delay_sky130", 0)
-    baseline_runtime = baseline_result.get("runtime_ms", 0)
 
     for tool in sorted(comparison.keys()):
         result = comparison[tool]
@@ -1672,7 +1755,6 @@ def display_markdown(comparison, metric_filter=None):
             fmt(result.get("delay_asap7"), baseline_delay_asap7),
             fmt(result.get("area_sky130"), baseline_area_sky130),
             fmt(result.get("delay_sky130"), baseline_delay_sky130),
-            fmt(result.get("runtime_ms"), baseline_runtime),
         ]
         rows.append(row)
 
@@ -1711,7 +1793,6 @@ def display_html(comparison, benchmark_name, metric_filter=None):
             <th>Delay (ASAP7)</th>
             <th>Area (Sky130)</th>
             <th>Delay (Sky130)</th>
-            <th>Runtime (ms)</th>
         </tr>
 """
 
@@ -1727,7 +1808,6 @@ def display_html(comparison, benchmark_name, metric_filter=None):
             <td>{result.get("delay_asap7", "N/A")}</td>
             <td>{result.get("area_sky130", "N/A")}</td>
             <td>{result.get("delay_sky130", "N/A")}</td>
-            <td>{result.get("runtime_ms", "N/A")}</td>
         </tr>
 """
 

--- a/src/circt_synth_tracker/tools/circt_synth.py
+++ b/src/circt_synth_tracker/tools/circt_synth.py
@@ -13,6 +13,8 @@ Usage:
 
 import sys
 import os
+import re
+import json
 import subprocess
 import argparse
 import tempfile
@@ -30,6 +32,105 @@ def run_command(cmd, description):
         sys.exit(result.returncode)
 
     return result
+
+
+def _tv_sort_key(p):
+    """Sort key for MLIR pass output files by their numeric prefix (e.g. 0_10_ → (0,10))."""
+    m = re.match(r'^(\d+)_(\d+)_', p.name)
+    if m:
+        return (int(m.group(1)), int(m.group(2)))
+    m = re.match(r'^(\d+)_', p.name)
+    if m:
+        return (int(m.group(1)), float('inf'))
+    return (float('inf'), float('inf'))
+
+
+def _run_lec_pair(args, from_file, to_file):
+    """Run circt-lec on a pair of MLIR files and return status string.
+
+    When args.tv_solver is set, emit SMT-LIB and pipe to the external solver.
+    Otherwise use circt-lec --run directly.
+    Returns one of: "equiv", "non-equiv", "error", "timeout".
+    """
+    lec_base = [args.circt_lec, str(from_file), str(to_file)]
+    if args.top:
+        lec_base.extend(["--c1", args.top, "--c2", args.top])
+
+    if args.tv_solver:
+        # Emit SMT-LIB and pipe to external solver
+        lec_cmd = lec_base + ["--emit-smtlib"]
+        solver_cmd = args.tv_solver.split()
+        try:
+            lec_proc = subprocess.run(
+                lec_cmd, capture_output=True
+            )
+            if lec_proc.returncode != 0:
+                print(f"    circt-lec error: {lec_proc.stderr.decode()[:200]}", file=sys.stderr)
+                return "error"
+            solver_result = subprocess.run(
+                solver_cmd, input=lec_proc.stdout, capture_output=True, timeout=args.tv_timeout
+            )
+            out = solver_result.stdout.decode()
+            if "unsat" in out:
+                return "equiv"
+            elif "sat" in out:
+                return "non-equiv"
+            else:
+                print(f"    Solver unexpected output: {out[:200]}", file=sys.stderr)
+                return "error"
+        except subprocess.TimeoutExpired:
+            return "timeout"
+    else:
+        lec_cmd = lec_base + ["--run"]
+        try:
+            lec_result = subprocess.run(
+                lec_cmd, capture_output=True, text=True, timeout=args.tv_timeout
+            )
+            out = lec_result.stdout + lec_result.stderr
+            if "c1 == c2" in out:
+                return "equiv"
+            elif "c1 != c2" in out:
+                return "non-equiv"
+            else:
+                print(f"    Tool error: {out[:200]}", file=sys.stderr)
+                return "error"
+        except subprocess.TimeoutExpired:
+            return "timeout"
+
+
+def run_tv(args, mlir_file, synth_mlir_file, output_file, tree_dir):
+    """Run translation validation between consecutive pass outputs using circt-lec.
+
+    Collects all .mlir files under tree_dir, sorts them by their numeric prefix,
+    then runs circt-lec between each consecutive pair in the sequence:
+        input.mlir -> 0_0_... -> 0_1_... -> ... -> synth_output.mlir
+    """
+    tree_files = sorted(Path(tree_dir).rglob("*.mlir"), key=_tv_sort_key)
+
+    sequence = [mlir_file] + tree_files + [synth_mlir_file]
+
+    tv_results = []
+    overall_status = "pass"
+
+    for from_file, to_file in zip(sequence, sequence[1:]):
+        print(f"  TV: {from_file.name} -> {to_file.name}", file=sys.stderr)
+        status = _run_lec_pair(args, from_file, to_file)
+        if status == "non-equiv":
+            overall_status = "fail"
+            print(f"    NON-EQUIV detected!", file=sys.stderr)
+        elif status == "timeout":
+            print(f"    Timeout after {args.tv_timeout}s", file=sys.stderr)
+        if status not in ("equiv", "non-equiv") and overall_status not in ("fail",):
+            overall_status = "error"
+
+        tv_results.append({"from": from_file.name, "to": to_file.name, "status": status})
+
+    tv_sidecar = Path(str(output_file) + ".tv")
+    tv_sidecar.write_text(
+        json.dumps({"tv_status": overall_status, "tv_results": tv_results}, indent=2) + "\n"
+    )
+    print(f"  TV: overall_status={overall_status}, wrote {tv_sidecar}", file=sys.stderr)
+    return overall_status
 
 
 def main():
@@ -62,6 +163,25 @@ def main():
     parser.add_argument(
         "--lec-timeout", type=int, default=10,
         help="Timeout in seconds for circt-lec (default: 10)",
+    )
+    parser.add_argument(
+        "--run-tv", action="store_true",
+        help=(
+            "Run translation validation: dump per-pass MLIR via --mlir-print-ir-tree-dir "
+            "and verify equivalence between consecutive pass outputs using circt-lec"
+        ),
+    )
+    parser.add_argument(
+        "--tv-timeout", type=int, default=10,
+        help="Timeout in seconds per circt-lec invocation during TV (default: 10)",
+    )
+    parser.add_argument(
+        "--tv-solver", default="",
+        help=(
+            "External SMT solver command for TV (e.g. 'z3 -in' or 'bitwuzla'). "
+            "When set, circt-lec --emit-smtlib output is piped to this solver. "
+            "unsat=equiv, sat=non-equiv. Default: use circt-lec --run."
+        ),
     )
     parser.add_argument(
         "--keep-mlir", action="store_true", help="Keep intermediate MLIR files"
@@ -106,6 +226,7 @@ def main():
         synth_mlir_file = Path(synth_mlir_path)
         keep_synth_mlir = args.keep_mlir
 
+    tv_tree_dir = None
     try:
         # Step 1: Convert SystemVerilog to MLIR using circt-verilog
         verilog_cmd = [args.circt_verilog, str(input_file)]
@@ -128,6 +249,15 @@ def main():
         synth_cmd = [args.circt_synth, str(mlir_file)]
         if args.circt_synth_extra_args:
             synth_cmd.extend(args.circt_synth_extra_args.split())
+
+        if args.run_tv:
+            tv_tree_dir = tempfile.mkdtemp(suffix="-tv-ir-tree")
+            synth_cmd.extend([
+                f"--mlir-print-ir-tree-dir={tv_tree_dir}",
+                "-mlir-print-ir-after-all",
+                "-mlir-print-ir-after-change",
+            ])
+            print(f"  TV: dumping per-pass IR to {tv_tree_dir}", file=sys.stderr)
 
         print("Step 2: Synthesizing MLIR...", file=sys.stderr)
         result = run_command(synth_cmd, "MLIR synthesis")
@@ -172,6 +302,11 @@ def main():
                 print(f"  LEC: TIMEOUT after {args.lec_timeout}s.", file=sys.stderr)
                 lec_sidecar.write_text('{"lec_status": "timeout"}\n')
 
+        # Step 2c: Run translation validation if requested
+        if args.run_tv and tv_tree_dir:
+            print("Step 2c: Running translation validation (TV)...", file=sys.stderr)
+            run_tv(args, mlir_file, synth_mlir_file, output_file, tv_tree_dir)
+
         # Step 3: Export to AIG using circt-translate
         translate_cmd = [
             args.circt_translate,
@@ -192,6 +327,10 @@ def main():
             mlir_file.unlink()
         if not keep_synth_mlir and synth_mlir_file.exists():
             synth_mlir_file.unlink()
+        # Clean up TV tree dir
+        if tv_tree_dir is not None:
+            import shutil
+            shutil.rmtree(tv_tree_dir, ignore_errors=True)
 
     return 0
 


### PR DESCRIPTION
* Add --run-tv flag to circt-synth for per-pass equivalence checking via circt-lec
* Support external SMT solvers (e.g., Bitwuzla) for TV with --tv-solver
* Integrate TV into CI workflows and run-benchmark action
* Update HTML reports to display TV status and results with tooltips
* Add TV data aggregation and sidecar file support
* Adds --run-tv to run-circt-synth, which dumps per-pass MLIR using --mlir-print-ir-tree-dir and runs circt-lec between each consecutive pair of pass outputs. Results are written to a .tv sidecar JSON.