### PR TITLE
Deploy PR benchmarks to GitHub Pages

### DIFF
--- a/.github/workflows/ci-pr-benchmark.yml
+++ b/.github/workflows/ci-pr-benchmark.yml
@@ -31,8 +31,9 @@ on:
         default: true
 
 permissions:
-  contents: read
+  contents: write
   issues: write
+  pages: write
 
 # Keep the container image tag in sync with llvm/circt's buildAndTest.yml
 env:
@@ -267,8 +268,14 @@ jobs:
             const fs = require('fs');
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             let reportBody = '';
+            let truncated = false;
+            const MAX_REPORT_SIZE = 20000; // GitHub comment limit is ~65k, use 20k to be safe
             try {
               reportBody = fs.readFileSync('tracker/pr-report.md', 'utf8');
+              if (reportBody.length > MAX_REPORT_SIZE) {
+                reportBody = reportBody.substring(0, MAX_REPORT_SIZE) + '\n\n... *(truncated, see full report in artifacts)*';
+                truncated = true;
+              }
             } catch (e) {
               reportBody = '_Report not generated._';
             }
@@ -334,3 +341,24 @@ jobs:
           path: |
             tracker/build_before/
             tracker/build_after/
+
+      - name: Prepare deployment files
+        if: always()
+        run: |
+          # Create directory structure for deployment
+          PR_DIR="deploy/pr-benchmarks/pr-${{ inputs.pr_number }}"
+          mkdir -p "$PR_DIR"
+
+          # Copy only HTML report (markdown and JSON are available as artifacts)
+          cp tracker/pr-report.html "$PR_DIR/report.html" || true
+
+          echo "Deployment files prepared:"
+          ls -la deploy/
+
+      - name: Deploy to GitHub Pages
+        if: always()
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./deploy
+          keep_files: true


### PR DESCRIPTION
Add GitHub Pages deployment to ci-pr-benchmark workflow:
- Deploy HTML reports to pr-benchmarks/pr-{number}/ directory
- Use peaceiris/actions-gh-pages action for consistency with ci-nightly
- Keep existing reports on gh-pages branch with keep_files: true
- Update permissions to allow contents and pages write access